### PR TITLE
fix: Support omnifunc's alternative return type (dict)

### DIFF
--- a/lua/cmp_omni/init.lua
+++ b/lua/cmp_omni/init.lua
@@ -41,6 +41,12 @@ source.complete = function(self, params, callback)
     },
   }
 
+  -- As per :help complete-functions, a complete function may return a list
+  -- or a dictionary { words = <list>, refresh = 'always' }.
+  if result.words ~= nil then
+    result = result.words
+  end
+
   local items = {}
   for _, v in ipairs(result) do
     if type(v) == 'string' then


### PR DESCRIPTION
As per :help complete-functions, a complete function may return a list
or a dictionary `{ words = <list>, refresh = 'always' }`. This was not
previously recognized, silently resulting in "no completion results".

An example of such omnifunc is `vim.treesitter.query.omnifunc()`.

```
In order to return more information than the matching words, return a Dict
that contains the List.  The Dict can have these items:
	words		The List of matching words (mandatory).
	refresh		A string to control re-invocation of the function
			(optional).
			The only value currently recognized is "always", the
			effect is that the function is called whenever the
			leading text is changed.
Other items are ignored.
```

Note: workaround for `vim.treesitter.query.omnifunc` by monkey-patching until this gets merged:

```lua
-- Workaround https://github.com/hrsh7th/cmp-omni/pull/10
vim.treesitter.query.omnifunc = function(...)
  local ret = require('vim.treesitter._query_linter').omnifunc(...)
  return type(ret) == "table" and ret.words or ret
end
